### PR TITLE
Exlude Laravel 9 from PHP 7.4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,12 +13,14 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.0, 8.1]
-        laravel: [9.*]
+        php: [7.4, 8.0, 8.1, 8.2]
+        laravel: [8.*, 9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 9.*
             testbench: 7.*
+          - laravel: 8.*
+            testbench: 6.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,6 +21,9 @@ jobs:
             testbench: 7.*
           - laravel: 8.*
             testbench: 6.*
+        exclude:
+          - laravel: 9.*
+            php: 7.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^7.4",
         "brick/varexporter": "^0.3.7",
-        "illuminate/contracts": "^9.0",
+        "illuminate/contracts": "^8.0|^9.0",
         "livewire/livewire": "^2.10",
         "outhebox/blade-flags": "^1.0",
         "saade/blade-iconsax": "^1.0",
@@ -31,11 +31,11 @@
     "require-dev": {
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^6.0",
-        "orchestra/testbench": "^7.0",
+        "orchestra/testbench": "^6.0|^7.0",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.1",
         "pestphp/pest-plugin-livewire": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/AuthorizesRequests.php
+++ b/src/AuthorizesRequests.php
@@ -6,14 +6,14 @@ trait AuthorizesRequests
 {
     public static $authUsing;
 
-    public static function auth($callback): static
+    public static function auth($callback): self
     {
         static::$authUsing = $callback;
 
         return new static;
     }
 
-    public static function check($request): bool|string
+    public static function check($request)
     {
         return (static::$authUsing ?: function () {
             return app()->environment('local');

--- a/src/Console/Commands/ExportTranslationsCommand.php
+++ b/src/Console/Commands/ExportTranslationsCommand.php
@@ -7,13 +7,17 @@ use Outhebox\LaravelTranslations\TranslationsManager;
 
 class ExportTranslationsCommand extends Command
 {
+    public TranslationsManager $manager;
+
     protected $signature = 'translations:export';
 
     protected $description = 'Export all translations to the language directory';
 
-    public function __construct(public  TranslationsManager $manager)
+    public function __construct(TranslationsManager $manager)
     {
         parent::__construct();
+
+        $this->manager = $manager;
     }
 
     public function handle()

--- a/src/Console/Commands/ImportTranslationsCommand.php
+++ b/src/Console/Commands/ImportTranslationsCommand.php
@@ -13,13 +13,17 @@ use Outhebox\LaravelTranslations\TranslationsManager;
 
 class ImportTranslationsCommand extends Command
 {
+    public TranslationsManager $manager;
+
     protected $signature = 'translations:import {--F|fresh : Truncate all translations and phrases before importing}';
 
     protected $description = 'Sync translation all keys from the translation files to the database';
 
-    public function __construct(public  TranslationsManager $manager)
+    public function __construct(TranslationsManager $manager)
     {
         parent::__construct();
+
+        $this->manager = $manager;
     }
 
     protected function truncateTables()

--- a/src/TranslationsManager.php
+++ b/src/TranslationsManager.php
@@ -14,9 +14,11 @@ class TranslationsManager
 {
     private array $translations = [];
 
-    public function __construct(protected Filesystem $filesystem)
+    protected Filesystem $filesystem;
+
+    public function __construct(Filesystem $filesystem)
     {
-        //
+        $this->filesystem = $filesystem;
     }
 
     public function getLocales(): array


### PR DESCRIPTION
This PR excludes Laravel 9 from running on PHP 7.4, hopefully, that fixes your GH action. 🙂