### PR TITLE
Drop support for PHP 7.4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [7.4, 8.0, 8.1, 8.2]
+        php: [8.0, 8.1, 8.2]
         laravel: [8.*, 9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
@@ -21,9 +21,6 @@ jobs:
             testbench: 7.*
           - laravel: 8.*
             testbench: 6.*
-        exclude:
-          - laravel: 9.*
-            php: 7.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": "^8.0",
         "brick/varexporter": "^0.3.7",
         "illuminate/contracts": "^8.0|^9.0",
         "livewire/livewire": "^2.10",


### PR DESCRIPTION
As discussed in #11, dropping support for PHP 7.4. Fingers crossed your GitHub actions run smoothly now. 👍