### PR TITLE
Added the function to reverse the migration for this package

### DIFF
--- a/database/migrations/2018_08_08_100000_create_translations_tables.php
+++ b/database/migrations/2018_08_08_100000_create_translations_tables.php
@@ -6,6 +6,11 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
     public function up()
     {
         Schema::create('ltu_languages', function (Blueprint $table) {
@@ -40,5 +45,18 @@ return new class extends Migration
             $table->json('parameters')->nullable();
             $table->timestamps();
         });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('ltu_phrases');
+        Schema::dropIfExists('ltu_translation_files');
+        Schema::dropIfExists('ltu_translations');
+        Schema::dropIfExists('ltu_languages');
     }
 };


### PR DESCRIPTION
Title and the code are self-explanatory, nothing that complex overall.

All it does is using already existing function (logic) `down()` from Laravel `Migration` class
Giving you the ability to revert the changes done to database (removing tables that were added) using `php artisan rollback`

**NOTE:** Tested on fresh `Laravel v9.48.0 (PHP v8.2.0)` project and works without the issues.

P.S: Thanks for this awesome package you made, I'll try to contribute to it whenever I can 👍 
