### PR TITLE
RTL support for Pashto language

### DIFF
--- a/src/Console/Commands/ImportTranslationsCommand.php
+++ b/src/Console/Commands/ImportTranslationsCommand.php
@@ -480,7 +480,7 @@ class ImportTranslationsCommand extends Command
             [
                 'code' => 'ps',
                 'name' => 'Pashto',
-                'rtl' => false,
+                'rtl' => true,
             ],
             [
                 'code' => 'fa',


### PR DESCRIPTION
Pashto is Arabic & Persian extended language works on RTL. e.g: 
How are you? 
څنګه يي ؟