### PR TITLE
Update create_phrases_table.php

### DIFF
--- a/database/migrations/create_phrases_table.php
+++ b/database/migrations/create_phrases_table.php
@@ -21,7 +21,7 @@ return new class extends Migration
             $table->string('key');
             $table->string('group');
             $table->text('value')->nullable();
-            $table->text('status')->default(StatusEnum::active->value);
+            $table->string('status')->default(StatusEnum::active->value);
             $table->json('parameters')->nullable();
             $table->text('note')->nullable();
             $table->timestamps();


### PR DESCRIPTION
Solves the issue on the installation of running the migrations. Reference issue: https://github.com/MohmmedAshraf/laravel-translations/issues/53

In Connection.php line 822:
                                                                                                                                                                                                                                                                   
  SQLSTATE[42000]: Syntax error or access violation: 1101 BLOB, TEXT, GEOMETRY or JSON column 'status' can't have a default value (Connection: mysql, SQL: create table `ltu_phrases` (`id` bigint unsigned not null auto_increment primary key, `uuid` char(36)   
  not null, `translation_id` bigint unsigned not null, `translation_file_id` bigint unsigned not null, `phrase_id` bigint unsigned null, `key` varchar(255) not null, `group` varchar(255) not null, `value` text null, `status` longtext not null default 'activ  
  e', `parameters` json null, `note` text null, `created_at` timestamp null, `updated_at` timestamp null) default character set utf8mb4 collate 'utf8mb4_unicode_ci')                                                                                              
                                                                                                                                                                                                                                                                   

In Connection.php line 574:
                                                                                                                                   
  SQLSTATE[42000]: Syntax error or access violation: 1101 BLOB, TEXT, GEOMETRY or JSON column 'status' can't have a default value  
