### PR TITLE
Fix: Dot Notation for Nested Key Not Working

### DIFF
--- a/src/Http/Controllers/SourcePhraseController.php
+++ b/src/Http/Controllers/SourcePhraseController.php
@@ -54,7 +54,7 @@ class SourcePhraseController extends BaseController
     public function store(Request $request): RedirectResponse
     {
         $request->validate([
-            'key' => ['required', 'regex:/^[a-zA-Z_]+$/'],
+            'key' => ['required', 'regex:/^[a-zA-Z0-9_.]+$/'],
             'file' => ['required', 'integer', 'exists:ltu_translation_files,id'],
             'content' => ['required', 'string'],
         ]);


### PR DESCRIPTION
This PR Fixes #62, Adding dot notation for nested keys not working as expected. 