### PR TITLE
Fixes for JSON export

### DIFF
--- a/src/TranslationsManager.php
+++ b/src/TranslationsManager.php
@@ -31,8 +31,16 @@ class TranslationsManager
         }
 
         collect($this->filesystem->files(lang_path()))->each(function ($file) use ($locales) {
-            if ($this->filesystem->extension($file) != 'json') {
+            if ($this->filesystem->extension($file) !== 'json') {
                 return;
+            }
+            foreach (config('translations.exclude_files') as $excludeFile) {
+                if (fnmatch($excludeFile, $file)) {
+                    return;
+                }
+                if (fnmatch($excludeFile, basename($file))) {
+                    return;
+                }
             }
 
             if (! $locales->contains($file->getFilenameWithoutExtension())) {

--- a/src/TranslationsManager.php
+++ b/src/TranslationsManager.php
@@ -116,7 +116,11 @@ class TranslationsManager
 
             foreach ($phrasesTree as $locale => $groups) {
                 foreach ($groups as $file => $phrases) {
-                    $langPath = $download ? storage_path("app/translations/$locale/$file") : lang_path("$locale/$file");
+                    if ($file === "$locale.json") {
+                        $langPath = $download ? storage_path("app/translations/$file") : lang_path("$file");
+                    } else {
+                        $langPath = $download ? storage_path("app/translations/$locale/$file") : lang_path("$locale/$file");
+                    }
 
                     if (! $this->filesystem->isDirectory(dirname($langPath))) {
                         $this->filesystem->makeDirectory(dirname($langPath), 0755, true);
@@ -135,7 +139,7 @@ class TranslationsManager
                     }
 
                     if ($this->filesystem->extension($langPath) == 'json') {
-                        $this->filesystem->put($langPath, json_encode($phrases, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+                        $this->filesystem->put($langPath, json_encode($phrases, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
                     }
                 }
             }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -62,6 +62,7 @@ if (! function_exists('buildPhrasesTree')) {
         foreach ($phrases as $phrase) {
             if ($phrase->file->file_name === "$locale.json") {
                 $tree[$locale][$phrase->file->file_name][$phrase->key] = ! blank($phrase->value) ? $phrase->value : $phrase->source->value;
+
                 continue;
             }
             setArrayValue(


### PR DESCRIPTION
Decided to merge all 3 PRs into one as they are all related to JSON export:


1. When using along with https://github.com/xiCO2k/laravel-vue-i18n which generates "php_*.json" files along for every locale, I can ignore those files, but the ignored files are still by default used for locales.

For example:
If I have two locales, "et" and "ru", by default import is also trying to find locales for ignored files, and locales "php_et" and "php_ru" which do not exist.

2. As per Laravel documentation (https://laravel.com/docs/10.x/localization#introduction), the locale JSON files always reside in the main translations folder, not in the specific locale folder.
3. when exporting the JSON strings, dot in the keys are treated as start of a sub-translation, which is incorrect assumption.
4. When exporting to JSON, slashes are escaped by default which is not expected behaviour, as translations from JSON files are stored/used unescaped.