### PR TITLE
Should respect the locale JSON file structure set by Laravel

### DIFF
--- a/src/TranslationsManager.php
+++ b/src/TranslationsManager.php
@@ -108,7 +108,11 @@ class TranslationsManager
 
             foreach ($phrasesTree as $locale => $groups) {
                 foreach ($groups as $file => $phrases) {
-                    $langPath = $download ? storage_path("app/translations/$locale/$file") : lang_path("$locale/$file");
+                    if ($file === "$locale.json") {
+                        $langPath = $download ? storage_path("app/translations/$file") : lang_path("$file");
+                    } else {
+                        $langPath = $download ? storage_path("app/translations/$locale/$file") : lang_path("$locale/$file");
+                    }
 
                     if (! $this->filesystem->isDirectory(dirname($langPath))) {
                         $this->filesystem->makeDirectory(dirname($langPath), 0755, true);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -60,6 +60,10 @@ if (! function_exists('buildPhrasesTree')) {
 
         /** @var \Outhebox\TranslationsUI\Models\Phrase $phrase */
         foreach ($phrases as $phrase) {
+            if ($phrase->file->file_name === "$locale.json") {
+                $tree[$locale][$phrase->file->file_name][$phrase->key] = ! blank($phrase->value) ? $phrase->value : $phrase->source->value;
+                continue;
+            }
             setArrayValue(
                 array: $tree[$locale][$phrase->file->file_name],
                 key: $phrase->key,


### PR DESCRIPTION
As per Laravel documentation (https://laravel.com/docs/10.x/localization#introduction), the locale JSON files always reside in the main translations folder, not in the specific locale folder.

Second, when exporting the JSON strings, dot in the keys are trated as start of a sub translation, which is incorrect assumption.

This PR addresses both of those issues.