### PR TITLE
Fix translation key format

### DIFF
--- a/src/Http/Controllers/SourcePhraseController.php
+++ b/src/Http/Controllers/SourcePhraseController.php
@@ -54,7 +54,7 @@ class SourcePhraseController extends BaseController
     public function store(Request $request): RedirectResponse
     {
         $request->validate([
-            'key' => ['required', 'regex:/^[a-zA-Z0-9_.]+$/'],
+            'key' => ['required', 'regex:/^[\w. ]+$/u'],
             'file' => ['required', 'integer', 'exists:ltu_translation_files,id'],
             'content' => ['required', 'string'],
         ]);


### PR DESCRIPTION
This PR fixes #7 and allows spaces, numbers, underscores, and dots when adding a new key to the source translations language, for better support JSON language keys as well.