### PR TITLE
nested-folders-support

### DIFF
--- a/src/Actions/SyncPhrasesAction.php
+++ b/src/Actions/SyncPhrasesAction.php
@@ -26,10 +26,12 @@ class SyncPhrasesAction
         ]);
 
         $isRoot = $file === $locale.'.json' || $file === $locale.'.php';
+        $extension = pathinfo($file, PATHINFO_EXTENSION);
+        $filePath = str_replace('.'.$extension, '', str_replace($locale.DIRECTORY_SEPARATOR, '', $file));
 
         $translationFile = TranslationFile::firstOrCreate([
-            'name' => pathinfo($file, PATHINFO_FILENAME),
-            'extension' => pathinfo($file, PATHINFO_EXTENSION),
+            'name' => $filePath,
+            'extension' => $extension,
             'is_root' => $isRoot,
         ]);
 

--- a/src/TranslationsManager.php
+++ b/src/TranslationsManager.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Outhebox\TranslationsUI\Models\Translation;
+use Symfony\Component\Finder\SplFileInfo;
 use ZipArchive;
 
 class TranslationsManager
@@ -67,8 +68,11 @@ class TranslationsManager
         }
 
         collect($files)
-            ->map(function ($file) use ($locale) {
-                return $locale.DIRECTORY_SEPARATOR.$file->getFilename();
+            ->map(function (SplFileInfo $file) use ($locale) {
+                if ($file->getRelativePath() === '') {
+                    return $locale.DIRECTORY_SEPARATOR.$file->getFilename();
+                }
+                return $locale.DIRECTORY_SEPARATOR.$file->getRelativePath().DIRECTORY_SEPARATOR.$file->getFilename();
             })
             ->when($this->filesystem->exists(lang_path($rootFileName)), function ($collection) use ($rootFileName) {
                 return $collection->prepend($rootFileName);
@@ -103,7 +107,6 @@ class TranslationsManager
                     $translations[$file] = [];
                 }
             });
-
         return $translations;
     }
 


### PR DESCRIPTION
### Added support for nested folders

**No one in big project is going to add loot of files in single folder. They will use nested folders.**

**This update read file and get its relative path to language folder and stores complete path.**

**Then it can change and update translations for those and also exports to the same relative path in each language folder.**

It may not be the best way to do that but I did it according to my need. If anything needs to update, you can ping me.

@MohmmedAshraf 