### PR TITLE
Fixed a bug with importing identical keys from different files

### DIFF
--- a/resources/views/pages/phrases/phrase-item.vue
+++ b/resources/views/pages/phrases/phrase-item.vue
@@ -18,7 +18,7 @@ defineProps<{
             <Link :href="route('ltu.phrases.edit', { translation: translation.id, phrase: phrase.uuid })" class="grid w-full grid-cols-2 divide-x md:grid-cols-3">
                 <div class="flex w-full items-center justify-start px-4">
                     <div class="truncate rounded-md border bg-white px-1.5 py-0.5 text-sm font-medium text-gray-600 hover:border-blue-400 hover:bg-blue-50 hover:text-blue-600">
-                        {{ phrase.key }}
+                        {{ phrase.group }}.{{ phrase.key }}
                     </div>
                 </div>
 

--- a/resources/views/pages/source/source-phrase-item.vue
+++ b/resources/views/pages/source/source-phrase-item.vue
@@ -33,7 +33,7 @@ watch(
             <Link :href="route('ltu.source_translation.edit', phrase.uuid)" class="grid w-full grid-cols-2 divide-x">
                 <div class="flex w-full items-center justify-start px-4">
                     <div class="truncate rounded-md border bg-white px-1.5 py-0.5 text-sm font-medium text-gray-600 hover:border-blue-400 hover:bg-blue-50 hover:text-blue-600">
-                        {{ phrase.key }}
+                        {{ phrase.group }}.{{ phrase.key }}
                     </div>
                 </div>
 

--- a/src/Console/Commands/ImportTranslationsCommand.php
+++ b/src/Console/Commands/ImportTranslationsCommand.php
@@ -127,7 +127,7 @@ class ImportTranslationsCommand extends Command
         $source->load('phrases.translation', 'phrases.file');
 
         $source->phrases->each(function ($phrase) use ($translation, $locale) {
-            if (! $translation->phrases()->where('key', $phrase->key)->first()) {
+            if (! $translation->phrases()->where('key', $phrase->key)->where('group', $phrase->group)->first()) {
                 $fileName = $phrase->file->name.'.'.$phrase->file->extension;
 
                 if ($phrase->file->name === config('translations.source_language')) {


### PR DESCRIPTION
As title says, I considered this a major problem so I quickly fixed it.

This request also includes optional change to show group in listing which is personal preference but I think it should be included for clarity in cases where files are used to separate translations of features. 