### PR TITLE
Use the schema of the selected database when running the 'ImportTramslationsCommand'.

### DIFF
--- a/src/Console/Commands/ImportTranslationsCommand.php
+++ b/src/Console/Commands/ImportTranslationsCommand.php
@@ -3,6 +3,7 @@
 namespace Outhebox\TranslationsUI\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Database\Schema\Builder as SchemaBuilder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
@@ -50,7 +51,7 @@ class ImportTranslationsCommand extends Command
 
     protected function importLanguages(): void
     {
-        if (! Schema::hasTable('ltu_languages') || Language::count() === 0) {
+        if (! $this->getSchema()->hasTable('ltu_languages') || Language::count() === 0) {
             if ($this->confirm('The ltu_languages table does not exist or is empty, would you like to install the default languages?', true)) {
                 $this->call('db:seed', ['--class' => LanguagesTableSeeder::class]);
             } else {
@@ -63,11 +64,16 @@ class ImportTranslationsCommand extends Command
 
     protected function truncateTables(): void
     {
-        Schema::withoutForeignKeyConstraints(function () {
+        $this->getSchema()->withoutForeignKeyConstraints(function () {
             Phrase::truncate();
             Translation::truncate();
             TranslationFile::truncate();
         });
+    }
+
+    protected function getSchema(): SchemaBuilder
+    {
+        return Schema::connection(config('translations.database_connection'));
     }
 
     public function createOrGetSourceLanguage(): Translation


### PR DESCRIPTION
My application uses multiple databases (for a multi-tenancy structure I will not get into) and I found out that I had to modify the import command to make the `Schema::` facade logic work. This is a PR to do that.

This is my first open source contribution, please be nice I have missed anything. I really love the package!

You can test this by setting up another database alongside your main database and setting it's connection as the `'database_connection'` in the config. Then run the migrations in that database and assert that the import command (and `import --fresh`) works. Of course it should also still works if the tables are in the main database and `'database_connection'` is `null`