### PR TITLE
sync uuid creation column with the new upgrade

### DIFF
--- a/database/migrations/create_phrases_table.php
+++ b/database/migrations/create_phrases_table.php
@@ -21,7 +21,7 @@ return new class extends Migration
     {
         Schema::create('ltu_phrases', function (Blueprint $table) {
             $table->id();
-            $table->uuid();
+            $table->char('uuid', 36);;
             $table->foreignIdFor(Translation::class)->constrained('ltu_translations')->cascadeOnDelete();
             $table->foreignIdFor(TranslationFile::class)->constrained('ltu_translation_files')->cascadeOnDelete();
             $table->foreignIdFor(Phrase::class)->nullable()->constrained('ltu_phrases')->cascadeOnDelete();


### PR DESCRIPTION
# Fix UUID column type for MariaDB compatibility

## Problem
When using MariaDB as the database driver for Laravel Translations UI, the migration fails due to an incompatibility with the `uuid` column type. This occurs because MariaDB doesn't natively support the `uuid` data type.

## Error
Running the migration `2024_09_05_100938_create_phrases_table` results in the following error:

```
SQLSTATE[HY000]: General error: 4161 Unknown data type: 'uuid'
```

## Solution
Update the migration file to use `char(36)` instead of `uuid()` for MariaDB compatibility. This change aligns with Laravel's recommendation for handling UUIDs in MariaDB as mentioned in the upgrade guide.

## Changes
In the migration file `create_phrases_table`, replace:

```php
$table->uuid();
```

with:

```php
$table->char('uuid', 36);
```

## Benefits
- Ensures compatibility with MariaDB while maintaining UUID functionality
- Follows Laravel's recommended approach for handling UUIDs in MariaDB environments
- Allows successful migration and installation of Laravel Translations UI with MariaDB

## Testing
- [x] Tested with MariaDB to ensure successful migration
- [x] Verified UUID generation and storage work as expected
- [ ] Tested with other supported databases to ensure no regression

## Additional Notes
This change is specific to MariaDB compatibility and should not affect the functionality of the package when used with other database systems that support the native `uuid()` method.

---

Closes #[Issue Number]