### PR TITLE
Fix file name wrong change

### DIFF
--- a/src/Actions/SyncPhrasesAction.php
+++ b/src/Actions/SyncPhrasesAction.php
@@ -27,7 +27,7 @@ class SyncPhrasesAction
 
         $isRoot = $file === $locale.'.json' || $file === $locale.'.php';
         $extension = pathinfo($file, PATHINFO_EXTENSION);
-        $filePath = str_replace('.'.$extension, '', preg_replace('/^'.$locale.DIRECTORY_SEPARATOR, '', $file));
+        $filePath = str_replace('.'.$extension, '', preg_replace('/^' . preg_quote($locale . DIRECTORY_SEPARATOR, '/') . '/', '', $file));
 
         $translationFile = TranslationFile::firstOrCreate([
             'name' => $filePath,

--- a/src/Actions/SyncPhrasesAction.php
+++ b/src/Actions/SyncPhrasesAction.php
@@ -27,7 +27,7 @@ class SyncPhrasesAction
 
         $isRoot = $file === $locale.'.json' || $file === $locale.'.php';
         $extension = pathinfo($file, PATHINFO_EXTENSION);
-        $filePath = str_replace('.'.$extension, '', str_replace($locale.DIRECTORY_SEPARATOR, '', $file));
+        $filePath = str_replace('.'.$extension, '', preg_replace('/^'.$locale.DIRECTORY_SEPARATOR, '', $file));
 
         $translationFile = TranslationFile::firstOrCreate([
             'name' => $filePath,

--- a/src/Actions/SyncPhrasesAction.php
+++ b/src/Actions/SyncPhrasesAction.php
@@ -27,7 +27,7 @@ class SyncPhrasesAction
 
         $isRoot = $file === $locale.'.json' || $file === $locale.'.php';
         $extension = pathinfo($file, PATHINFO_EXTENSION);
-        $filePath = str_replace('.'.$extension, '', preg_replace('/^' . preg_quote($locale . DIRECTORY_SEPARATOR, '/') . '/', '', $file));
+        $filePath = str_replace('.'.$extension, '', preg_replace('/^'.preg_quote($locale.DIRECTORY_SEPARATOR, '/').'/', '', $file));
 
         $translationFile = TranslationFile::firstOrCreate([
             'name' => $filePath,


### PR DESCRIPTION
I need to explain the case clearly

I had a translation file which was called pages/auth and every time I try to import or export the translations the file name will be converted to pagauth in the Spanish Language for some reason,

until I went through the package file and found this line:
$filePath = str_replace('.'.$extension, '', str_replace($locale.DIRECTORY_SEPARATOR, '', $file));
in the SyncPhrasesAction file

which in my case will replace the es/ part with nothing in this file pages/auth to become pagauth.

after playing around with the code I found out it's meant to replace the first part of the translations file as it'll be passed to the SyncPhrasesAction as `es/pages/auth.php` so there no need to use the aggressive `str_replace` and instead use `preg_replace` with the `^` flag will make the function make sure that it's searching for the locale name in the start of the file name instead of the whole file name