### PR TITLE
Fix asset paths for non-root project setups

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -32,9 +32,12 @@ if (! function_exists('translationsUIAssets')) {
 
         $manifest = json_decode(file_get_contents($manifestPath), true);
 
+        $file = asset("/vendor/translations-ui/{$manifest['resources/scripts/app.ts']['file']}");
+        $css = asset("/vendor/translations-ui/{$manifest['resources/scripts/app.ts']['css'][0]}");
+
         return new HtmlString(<<<HTML
-                <script type="module" src="/vendor/translations-ui/{$manifest['resources/scripts/app.ts']['file']}"></script>
-                <link rel="stylesheet" href="/vendor/translations-ui/{$manifest['resources/scripts/app.ts']['css'][0]}">
+                <script type="module" src="{$file}"></script>
+                <link rel="stylesheet" href="{$css}">
             HTML
         );
     }


### PR DESCRIPTION
Replaced hardcoded asset paths with `asset()` helper to ensure assets are loaded correctly when the project is served from a subdirectory. This change modifies the script and stylesheet links in the HTML string to dynamically generate the correct paths, supporting projects served from a path other than the root.