### PR TITLE
`xResource::withoutWrapping()` should not affect `JsonResource` superclass

### DIFF
--- a/src/Http/Resources/ContributorResource.php
+++ b/src/Http/Resources/ContributorResource.php
@@ -8,6 +8,8 @@ use Outhebox\TranslationsUI\Models\Contributor;
 /** @mixin Contributor */
 class ContributorResource extends JsonResource
 {
+    public static $wrap = null;
+
     public function toArray($request): array
     {
         return [

--- a/src/Http/Resources/InviteResource.php
+++ b/src/Http/Resources/InviteResource.php
@@ -9,6 +9,8 @@ use Outhebox\TranslationsUI\Models\Invite;
 /** @mixin Invite */
 class InviteResource extends JsonResource
 {
+    public static $wrap = null;
+
     public function toArray(Request $request): array
     {
         return [

--- a/src/Http/Resources/LanguageResource.php
+++ b/src/Http/Resources/LanguageResource.php
@@ -8,6 +8,8 @@ use Outhebox\TranslationsUI\Models\Language;
 /** @mixin Language */
 class LanguageResource extends JsonResource
 {
+    public static $wrap = null;
+
     public function toArray($request): array
     {
         return [

--- a/src/Http/Resources/PhraseResource.php
+++ b/src/Http/Resources/PhraseResource.php
@@ -9,6 +9,8 @@ use Outhebox\TranslationsUI\Models\Phrase;
 /** @mixin Phrase */
 class PhraseResource extends JsonResource
 {
+    public static $wrap = null;
+
     public function toArray(Request $request): array
     {
         return [

--- a/src/Http/Resources/TranslationFileResource.php
+++ b/src/Http/Resources/TranslationFileResource.php
@@ -9,6 +9,8 @@ use Outhebox\TranslationsUI\Models\TranslationFile;
 /** @mixin TranslationFile */
 class TranslationFileResource extends JsonResource
 {
+    public static $wrap = null;
+
     public function toArray(Request $request): array
     {
         return [

--- a/src/Http/Resources/TranslationResource.php
+++ b/src/Http/Resources/TranslationResource.php
@@ -12,6 +12,8 @@ use Outhebox\TranslationsUI\Models\Translation;
  */
 class TranslationResource extends JsonResource
 {
+    public static $wrap = null;
+
     public function toArray($request): array
     {
         return [

--- a/tests/TranslationsUIServiceProviderTest.php
+++ b/tests/TranslationsUIServiceProviderTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Outhebox\TranslationsUI\Http\Resources\PhraseResource;
+
+it('withoutWrapping does not affect JsonResource superclass', function () {
+
+    $translationsManager = new \Outhebox\TranslationsUI\TranslationsUIServiceProvider($this->app);
+    $translationsManager->packageBooted();
+
+    expect(JsonResource::$wrap)->toBe('data')
+        ->and(PhraseResource::$wrap)->toBe(null);
+});


### PR DESCRIPTION
Where `class ContributorResource extends JsonResource`, calling the `ContributorResource::withoutWrapping()` is really calling `JsonResource::withoutWrapping()` which was then setting the `public static $wrap` _of_ `JsonResource` to `null`, rather than acting on the subclass.

By adding the property to each subclass, calling `:withoutWrapping()` changes the property only on the subclass and not on the super class.