### PR TITLE
Add `UnwrappedAnonymousResourceCollection`

### DIFF
--- a/src/Http/Resources/ContributorResource.php
+++ b/src/Http/Resources/ContributorResource.php
@@ -37,6 +37,6 @@ class ContributorResource extends JsonResource
      */
     protected static function newCollection($resource)
     {
-        return new UnwrappedAnonymousResourceCollection($resource, TranslationResource::class);
+        return new UnwrappedAnonymousResourceCollection($resource, ContributorResource::class);
     }
 }

--- a/src/Http/Resources/ContributorResource.php
+++ b/src/Http/Resources/ContributorResource.php
@@ -3,6 +3,7 @@
 namespace Outhebox\TranslationsUI\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Collection;
 use Outhebox\TranslationsUI\Models\Contributor;
 
 /** @mixin Contributor */
@@ -24,5 +25,18 @@ class ContributorResource extends JsonResource
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];
+    }
+
+    /**
+     * Create an AnonymousResourceCollection without wrapping
+     *
+     * @see JsonResource::newCollection()
+     *
+     * @param  mixed|Collection  $resource
+     * @return UnwrappedAnonymousResourceCollection
+     */
+    protected static function newCollection($resource)
+    {
+        return new UnwrappedAnonymousResourceCollection($resource, TranslationResource::class);
     }
 }

--- a/src/Http/Resources/InviteResource.php
+++ b/src/Http/Resources/InviteResource.php
@@ -37,6 +37,6 @@ class InviteResource extends JsonResource
      */
     protected static function newCollection($resource)
     {
-        return new UnwrappedAnonymousResourceCollection($resource, TranslationResource::class);
+        return new UnwrappedAnonymousResourceCollection($resource, InviteResource::class);
     }
 }

--- a/src/Http/Resources/InviteResource.php
+++ b/src/Http/Resources/InviteResource.php
@@ -4,6 +4,7 @@ namespace Outhebox\TranslationsUI\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Collection;
 use Outhebox\TranslationsUI\Models\Invite;
 
 /** @mixin Invite */
@@ -24,5 +25,18 @@ class InviteResource extends JsonResource
             'languages' => $this->languages,
             'invited_at' => $this->created_at->format('D, d M Y h:i A'),
         ];
+    }
+
+    /**
+     * Create an AnonymousResourceCollection without wrapping
+     *
+     * @see JsonResource::newCollection()
+     *
+     * @param  mixed|Collection  $resource
+     * @return UnwrappedAnonymousResourceCollection
+     */
+    protected static function newCollection($resource)
+    {
+        return new UnwrappedAnonymousResourceCollection($resource, TranslationResource::class);
     }
 }

--- a/src/Http/Resources/LanguageResource.php
+++ b/src/Http/Resources/LanguageResource.php
@@ -3,6 +3,7 @@
 namespace Outhebox\TranslationsUI\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Collection;
 use Outhebox\TranslationsUI\Models\Language;
 
 /** @mixin Language */
@@ -18,5 +19,18 @@ class LanguageResource extends JsonResource
             'code' => $this->code,
             'rtl' => $this->rtl,
         ];
+    }
+
+    /**
+     * Create an AnonymousResourceCollection without wrapping
+     *
+     * @see JsonResource::newCollection()
+     *
+     * @param  mixed|Collection  $resource
+     * @return UnwrappedAnonymousResourceCollection
+     */
+    protected static function newCollection($resource)
+    {
+        return new UnwrappedAnonymousResourceCollection($resource, TranslationResource::class);
     }
 }

--- a/src/Http/Resources/LanguageResource.php
+++ b/src/Http/Resources/LanguageResource.php
@@ -31,6 +31,6 @@ class LanguageResource extends JsonResource
      */
     protected static function newCollection($resource)
     {
-        return new UnwrappedAnonymousResourceCollection($resource, TranslationResource::class);
+        return new UnwrappedAnonymousResourceCollection($resource, LanguageResource::class);
     }
 }

--- a/src/Http/Resources/PhraseResource.php
+++ b/src/Http/Resources/PhraseResource.php
@@ -70,6 +70,6 @@ class PhraseResource extends JsonResource
      */
     protected static function newCollection($resource)
     {
-        return new UnwrappedAnonymousResourceCollection($resource, TranslationResource::class);
+        return new UnwrappedAnonymousResourceCollection($resource, PhraseResource::class);
     }
 }

--- a/src/Http/Resources/PhraseResource.php
+++ b/src/Http/Resources/PhraseResource.php
@@ -4,6 +4,7 @@ namespace Outhebox\TranslationsUI\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Collection;
 use Outhebox\TranslationsUI\Models\Phrase;
 
 /** @mixin Phrase */
@@ -57,5 +58,18 @@ class PhraseResource extends JsonResource
         }
 
         return $result->toArray();
+    }
+
+    /**
+     * Create an AnonymousResourceCollection without wrapping
+     *
+     * @see JsonResource::newCollection()
+     *
+     * @param  mixed|Collection  $resource
+     * @return UnwrappedAnonymousResourceCollection
+     */
+    protected static function newCollection($resource)
+    {
+        return new UnwrappedAnonymousResourceCollection($resource, TranslationResource::class);
     }
 }

--- a/src/Http/Resources/TranslationFileResource.php
+++ b/src/Http/Resources/TranslationFileResource.php
@@ -3,6 +3,7 @@
 namespace Outhebox\TranslationsUI\Http\Resources;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Collection;
 use Outhebox\TranslationsUI\Models\TranslationFile;
@@ -21,5 +22,19 @@ class TranslationFileResource extends JsonResource
             'nameWithExtension' => "$this->name.$this->extension",
             'phrases' => PhraseResource::collection($this->whenLoaded('phrases')),
         ];
+    }
+
+    /**
+     * Create an AnonymousResourceCollection without wrapping
+     *
+     * @see JsonResource::newCollection()
+     *
+     * @param  mixed|Collection  $resource
+     * @return UnwrappedAnonymousResourceCollection
+     * @return AnonymousResourceCollection
+     */
+    protected static function newCollection($resource)
+    {
+        return new UnwrappedAnonymousResourceCollection($resource, TranslationFileResource::class);
     }
 }

--- a/src/Http/Resources/TranslationFileResource.php
+++ b/src/Http/Resources/TranslationFileResource.php
@@ -4,6 +4,7 @@ namespace Outhebox\TranslationsUI\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Collection;
 use Outhebox\TranslationsUI\Models\TranslationFile;
 
 /** @mixin TranslationFile */
@@ -20,5 +21,18 @@ class TranslationFileResource extends JsonResource
             'nameWithExtension' => "$this->name.$this->extension",
             'phrases' => PhraseResource::collection($this->whenLoaded('phrases')),
         ];
+    }
+
+    /**
+     * Create an AnonymousResourceCollection without wrapping
+     *
+     * @see JsonResource::newCollection()
+     *
+     * @param  mixed|Collection  $resource
+     * @return UnwrappedAnonymousResourceCollection
+     */
+    protected static function newCollection($resource)
+    {
+        return new UnwrappedAnonymousResourceCollection($resource, TranslationResource::class);
     }
 }

--- a/src/Http/Resources/TranslationFileResource.php
+++ b/src/Http/Resources/TranslationFileResource.php
@@ -22,17 +22,4 @@ class TranslationFileResource extends JsonResource
             'phrases' => PhraseResource::collection($this->whenLoaded('phrases')),
         ];
     }
-
-    /**
-     * Create an AnonymousResourceCollection without wrapping
-     *
-     * @see JsonResource::newCollection()
-     *
-     * @param  mixed|Collection  $resource
-     * @return UnwrappedAnonymousResourceCollection
-     */
-    protected static function newCollection($resource)
-    {
-        return new UnwrappedAnonymousResourceCollection($resource, TranslationResource::class);
-    }
 }

--- a/src/Http/Resources/TranslationResource.php
+++ b/src/Http/Resources/TranslationResource.php
@@ -3,6 +3,7 @@
 namespace Outhebox\TranslationsUI\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Collection;
 use Outhebox\TranslationsUI\Models\Translation;
 
 /**
@@ -34,5 +35,18 @@ class TranslationResource extends JsonResource
         }
 
         return '0%';
+    }
+
+    /**
+     * Create an AnonymousResourceCollection without wrapping
+     *
+     * @see JsonResource::newCollection()
+     *
+     * @param  mixed|Collection  $resource
+     * @return UnwrappedAnonymousResourceCollection
+     */
+    protected static function newCollection($resource)
+    {
+        return new UnwrappedAnonymousResourceCollection($resource, TranslationResource::class);
     }
 }

--- a/src/Http/Resources/UnwrappedAnonymousResourceCollection.php
+++ b/src/Http/Resources/UnwrappedAnonymousResourceCollection.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Outhebox\TranslationsUI\Http\Resources;
+
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class UnwrappedAnonymousResourceCollection extends AnonymousResourceCollection
+{
+    public static $wrap = null;
+}

--- a/src/TranslationsUIServiceProvider.php
+++ b/src/TranslationsUIServiceProvider.php
@@ -14,6 +14,7 @@ use Outhebox\TranslationsUI\Http\Resources\InviteResource;
 use Outhebox\TranslationsUI\Http\Resources\LanguageResource;
 use Outhebox\TranslationsUI\Http\Resources\PhraseResource;
 use Outhebox\TranslationsUI\Http\Resources\TranslationFileResource;
+use Outhebox\TranslationsUI\Http\Resources\TranslationResource;
 use Outhebox\TranslationsUI\Models\Contributor;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
@@ -81,7 +82,7 @@ class TranslationsUIServiceProvider extends PackageServiceProvider
         LanguageResource::withoutWrapping();
         ContributorResource::withoutWrapping();
         TranslationFileResource::withoutWrapping();
-        TranslationFileResource::withoutWrapping();
+        TranslationResource::withoutWrapping();
     }
 
     private function registerAuthDriver(): void


### PR DESCRIPTION
My apologies, #144 introduced a bug which prevented correct rendering.

Since previously calling `::withoutWrapping()` was setting the `::$wrap` value on the `JsonResource` superclass, and the previous PR narrowed that to only change it on specific classes, the wrapping for `AnonymousResourceCollection` remained as `data` when the library's preference is for `null`.

This PR introduces a `UnwrappedAnonymousResourceCollection` class and overrides each `class x extends JsonResource` `protected static function newCollection($resource)` method to use this.

I also noticed in `TranslationsUIServiceProvider::packageBooted()` there was a duplicate `TranslationFileResource::withoutWrapping();` – I assume one should be `TranslationResource::withoutWrapping();`. Although with the `::$wrap` value set in each class now, those method calls may be unnecessary.

I'm not certain that each of these classes _needs_ this change, but it does return the behaviour to how it was before _for these_ classes. I.e. some of the methods might never be used; the ones that are, it's the correct change.