### PR TITLE
When checking for existing phrase, check the group AND key.

### DIFF
--- a/src/Actions/SyncPhrasesAction.php
+++ b/src/Actions/SyncPhrasesAction.php
@@ -44,7 +44,7 @@ class SyncPhrasesAction
         ], [
             'value' => (empty($value) ? null : $value),
             'parameters' => getPhraseParameters($value),
-            'phrase_id' => $translation->source ? null : $source->phrases()->where('key', $key)->first()?->id,
+            'phrase_id' => $translation->source ? null : $source->phrases()->where('key', $key)->where('group', $translationFile->name)->first()?->id,
         ]);
     }
 }

--- a/src/Console/Commands/ImportTranslationsCommand.php
+++ b/src/Console/Commands/ImportTranslationsCommand.php
@@ -139,7 +139,7 @@ class ImportTranslationsCommand extends Command
         $source->load('phrases.translation', 'phrases.file');
 
         $source->phrases->each(function ($phrase) use ($translation, $locale) {
-            if (! $translation->phrases()->where('key', $phrase->key)->first()) {
+            if (! $translation->phrases()->where('key', $phrase->key)->where('group', $phrase->group)->first()) {
                 $fileName = $phrase->file->name.'.'.$phrase->file->extension;
 
                 if ($phrase->file->name === config('translations.source_language')) {

--- a/tests/Actions/SyncPhrasesActionTest.php
+++ b/tests/Actions/SyncPhrasesActionTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use Outhebox\TranslationsUI\Actions\SyncPhrasesAction;
+use Outhebox\TranslationsUI\Models\Language;
+use Outhebox\TranslationsUI\Models\Phrase;
+use Outhebox\TranslationsUI\Models\Translation;
+
+it('can sync phrases with same keys in different groups', function () {
+    // Setup
+    $english = Language::factory()
+        ->create([
+            'rtl' => false,
+            'code' => 'en',
+            'name' => 'English',
+        ]);
+
+    $dutch = Language::factory()
+        ->create([
+            'rtl' => false,
+            'code' => 'nl',
+            'name' => 'Nederlands',
+        ]);
+
+    $englishTranslation = Translation::factory()
+        ->source()
+        ->create([
+            'language_id' => $english->id,
+        ]);
+
+    $englighAuthorsTitle = Phrase::factory()->create([
+        'key' => 'title',
+        'translation_id' => $englishTranslation->id,
+        'group' => 'authors',
+        'value' => 'Authors', // Dutch: Schrijvers
+    ]);
+
+    $englighBooksTitle = Phrase::factory()->create([
+        'key' => 'title',
+        'translation_id' => $englishTranslation->id,
+        'group' => 'books',
+        'value' => 'Books', // Dutch: Boeken
+    ]);
+
+    Phrase::bootHasUuid(); // IDK why this is needed... without this we get an integrity constraint violation for empty uuid.
+
+    // When
+    SyncPhrasesAction::execute(
+        $englishTranslation,
+        'title',
+        'Schrijvers',
+        'nl',
+        'authors.php',
+    );
+
+    SyncPhrasesAction::execute(
+        $englishTranslation,
+        'title',
+        'Boeken',
+        'nl',
+        'books.php',
+    );
+
+    // Then
+    $dutchTranslation = $dutch->translation;
+    expect($dutchTranslation)->toBeInstanceOf(Translation::class);
+
+    $dutchPhrases = $dutchTranslation->phrases;
+    expect($dutchPhrases)->toHaveCount(2);
+
+    expect($dutchPhrases[0]->phrase_id)->toEqual($englighAuthorsTitle->id);
+    expect($dutchPhrases[0]->key)->toEqual($englighAuthorsTitle->key);
+    expect($dutchPhrases[0]->group)->toEqual($englighAuthorsTitle->group);
+    expect($dutchPhrases[0]->value)->toEqual('Schrijvers');
+
+    expect($dutchPhrases[1]->phrase_id)->toEqual($englighBooksTitle->id);
+    expect($dutchPhrases[1]->key)->toEqual($englighBooksTitle->key);
+    expect($dutchPhrases[1]->group)->toEqual($englighBooksTitle->group);
+    expect($dutchPhrases[1]->value)->toEqual('Boeken');
+});

--- a/tests/Commands/ImportTranslationsCommandTest.php
+++ b/tests/Commands/ImportTranslationsCommandTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use Outhebox\TranslationsUI\Models\Language;
+use Outhebox\TranslationsUI\Models\Phrase;
+use Outhebox\TranslationsUI\Models\Translation;
+
+beforeEach(function () {
+    App::useLangPath(__DIR__.'lang_test');
+    createDirectoryIfNotExits(lang_path());
+});
+
+it('can import translations with same keys in diffent groups', function () {
+    // Given
+    $english = Language::factory()
+        ->create([
+            'rtl' => false,
+            'code' => 'en',
+            'name' => 'English',
+        ]);
+
+    $dutch = Language::factory()
+        ->create([
+            'rtl' => false,
+            'code' => 'nl',
+            'name' => 'Nederlands',
+        ]);
+
+    createPhpLanguageFile('en/authors.php', [
+        'title' => 'Authors'
+    ]);
+
+    createPhpLanguageFile('en/books.php', [
+        'title' => 'Books',
+    ]);
+
+    createPhpLanguageFile('nl/unrelated.php', []);
+
+    Phrase::bootHasUuid(); // IDK why this is needed... without this we get an integrity constraint violation for empty uuid.
+
+    // When
+    $this->artisan('translations:import')
+        ->assertExitCode(0);
+
+    // Then
+    $translation = $dutch->translation;
+    expect($translation)->toBeInstanceOf(Translation::class);
+
+    $phrases = $translation->phrases;
+    expect($phrases)->toHaveCount(2);
+});


### PR DESCRIPTION
This fixed #111 for me.

@digitalcraftlabs maybe my issue is different from yours...

I have a structure like:
```
lang/
    en/
        authors.php
        posts.php
``` 

authors.php looks like this:
```php
return [
    'page_title' => 'Authors',
];
``` 

posts.php looks like this:
```php
return [
    'page_title' => 'Posts',
];
``` 

When I load it into my database with translations for 'en' and 'nl' (Dutch), the `ltu_phrases` table looks like:

| id | translation_id | phrase_id | key        | group   |
|----|----------------|-----------|------------| --------|
|  1 |              1 |    `null` | page_title | authors |
|  2 |              1 |    `null` | page_title | posts   |
|  3 |              2 |         1 | page_title | authors |

As you can see, I am missing the Dutch phrase for `posts.page_title`. This is because the query that creates the missing `ltu_phrases` in the database only check for `key`, and the `key` `page_title` does indeed already exist for the Dutch locale. 