### PR TITLE
Update parameter types in SyncPhrasesAction::execute method

### DIFF
--- a/src/Actions/SyncPhrasesAction.php
+++ b/src/Actions/SyncPhrasesAction.php
@@ -8,7 +8,7 @@ use Outhebox\TranslationsUI\Models\TranslationFile;
 
 class SyncPhrasesAction
 {
-    public static function execute(Translation $source, $key, $value, $locale, $file, bool $overwrite = true): void
+    public static function execute(Translation $source, string $key, $value, string $locale, string $file, bool $overwrite = true): void
     {
         if (is_array($value) && empty($value)) {
             return;


### PR DESCRIPTION
While importing a large translation file, the first key was always overwritten by the last key. I use translation files in a Kubernetes-mounted volume. The changes in this PR have fixed my issue.