### PR TITLE
fix: freezing after save on translation page

### DIFF
--- a/src/Http/Controllers/TranslationController.php
+++ b/src/Http/Controllers/TranslationController.php
@@ -31,12 +31,12 @@ class TranslationController extends BaseController
         try {
             app(TranslationsManager::class)->export();
 
-            return redirect()->route('ltu.translation.index')->with('notification', [
+            return back()->with('notification', [
                 'type' => 'success',
                 'body' => 'Translations have been exported successfully',
             ]);
         } catch (Exception $e) {
-            return redirect()->route('ltu.translation.index')->with('notification', [
+            return back()->with('notification', [
                 'type' => 'error',
                 'body' => $e->getMessage(),
             ]);


### PR DESCRIPTION
This PR fixes the issue #143 

The `TranslationsController@export` method was performing a redirect() instead of back(), which prevented the modal's `onSuccess` callback from executing. Using back()->with() will allow the modal to close on any page Publish is used.