### PR TITLE
Phrase ID missing when syncing root file.

### DIFF
--- a/src/Actions/SyncPhrasesAction.php
+++ b/src/Actions/SyncPhrasesAction.php
@@ -36,6 +36,7 @@ class SyncPhrasesAction
         ]);
 
         $key = config('translations.include_file_in_key') && ! $isRoot ? "{$translationFile->name}.{$key}" : $key;
+        $group = $isRoot && config('translations.source_language') !== $locale ? $source->language->code : $translationFile->name;
         $method = $overwrite ? 'updateOrCreate' : 'firstOrCreate';
         $translation->phrases()->$method([
             'key' => $key,
@@ -44,7 +45,7 @@ class SyncPhrasesAction
         ], [
             'value' => (empty($value) ? null : $value),
             'parameters' => is_string($value) ? getPhraseParameters($value) : null,
-            'phrase_id' => $translation->source ? null : $source->phrases()->where('key', $key)->where('group', $translationFile->name)->first()?->id,
+            'phrase_id' => $translation->source ? null : $source->phrases()->where('key', $key)->where('group', $group)->first()?->id,
         ]);
     }
 }


### PR DESCRIPTION
The root files phrase_id adds null because the $translationFile->name is not the source group. The group is source->locale.