### PR TITLE
fix: check if missing translation group is different from source language 

### DIFF
--- a/src/Console/Commands/ImportTranslationsCommand.php
+++ b/src/Console/Commands/ImportTranslationsCommand.php
@@ -139,7 +139,11 @@ class ImportTranslationsCommand extends Command
         $source->load('phrases.translation', 'phrases.file');
 
         $source->phrases->each(function ($phrase) use ($translation, $locale) {
-            if (! $translation->phrases()->where('key', $phrase->key)->where('group', $phrase->group)->first()) {
+            if (
+                ! $translation->phrases()->where('key', $phrase->key)
+                    ->when($phrase->group != config('translations.source_language'), fn ($query) => $query->where('group', $phrase->group))
+                    ->first()
+            ) {
                 $fileName = $phrase->file->name.'.'.$phrase->file->extension;
 
                 if ($phrase->file->name === config('translations.source_language')) {

--- a/src/Console/Commands/ImportTranslationsCommand.php
+++ b/src/Console/Commands/ImportTranslationsCommand.php
@@ -139,9 +139,10 @@ class ImportTranslationsCommand extends Command
         $source->load('phrases.translation', 'phrases.file');
 
         $source->phrases->each(function ($phrase) use ($translation, $locale) {
+            $shouldFilterByGroup = $phrase->group !== config('translations.source_language');
             if (
                 ! $translation->phrases()->where('key', $phrase->key)
-                    ->when($phrase->group != config('translations.source_language'), fn ($query) => $query->where('group', $phrase->group))
+                    ->when($shouldFilterByGroup, fn ($query) => $query->where('group', $phrase->group))
                     ->first()
             ) {
                 $fileName = $phrase->file->name.'.'.$phrase->file->extension;


### PR DESCRIPTION
when having only json files for translations at import, the source language is imported and the phrases group is set to 'en' 

when importing the second language (eg: 'ro'),  syncMissingTranslations search on existing phrases key with group 'en' (from source phrase->group) and the result will always be null, therefore the translations will be updated to '' even if they exists.
