### PR TITLE
fix: TranslationResource has error on Model::shouldBeStrict

### DIFF
--- a/src/Http/Resources/TranslationResource.php
+++ b/src/Http/Resources/TranslationResource.php
@@ -24,14 +24,15 @@ class TranslationResource extends JsonResource
             'created_at' => $this->created_at->format('Y-m-d H:i:s'),
             'updated_at' => $this->updated_at?->format('Y-m-d H:i:s'),
             'progress' => $this->formatProgress(),
-            'phrases_count' => $this->phrases_count,
+            'phrases_count' => $this->whenCounted('phrases'),
         ];
     }
 
     private function formatProgress(): string
     {
-        if ($this->progress > 0) {
-            return "{$this->progress}%";
+        $progress = $this->resource->hasAttribute('progress') ? $this->resource->getAttribute('progress') : null;
+        if ($progress > 0) {
+            return "{$progress}%";
         }
 
         return '0%';


### PR DESCRIPTION
## AppServiceProvider::boot

```
Model::shouldBeStrict(true);
```

## Routes

`GET /translations/phrases/2/edit/a10b1bf1-806e-43c1-afe1-597f81a481ca`


## Exceptions

- The attribute [progress] either does not exist or was not retrieved for model [Outhebox\TranslationsUI\Models\Translation].

- The attribute [phrases_count] either does not exist or was not retrieved for model [Outhebox\TranslationsUI\Models\Translation].