### PR TITLE
Add Laravel 13 and PHP 8.5 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,13 +8,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.4, 8.3]
-        laravel: [12.*, 11.*]
+        php: [8.5, 8.4, 8.3]
+        laravel: [13.*, 12.*, 11.*]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*
             testbench: 9.*
+        exclude:
+          - laravel: 13.*
+            php: 8.3
 
     name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     ],
     "require": {
         "php": "^8.3",
-        "illuminate/contracts": "^11.0||^12.0",
-        "illuminate/support": "^11.0||^12.0",
+        "illuminate/contracts": "^11.0||^12.0||^13.0",
+        "illuminate/support": "^11.0||^12.0||^13.0",
         "inertiajs/inertia-laravel": "^2.0",
         "spatie/laravel-query-builder": "^6.0||^7.0"
     },
@@ -32,8 +32,8 @@
         "laravel/pint": "^1.0",
         "laravel/wayfinder": "^0.1",
         "nunomaduro/collision": "^8.0",
-        "orchestra/testbench": "^9.0||^10.0",
-        "orchestra/workbench": "^9.0||^10.0",
+        "orchestra/testbench": "^9.0||^10.0||^11.0",
+        "orchestra/workbench": "^9.0||^10.0||^11.0",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-laravel": "^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^8.3",
         "illuminate/contracts": "^11.0||^12.0||^13.0",
         "illuminate/support": "^11.0||^12.0||^13.0",
-        "inertiajs/inertia-laravel": "^2.0",
+        "inertiajs/inertia-laravel": "^2.0||^3.0",
         "spatie/laravel-query-builder": "^6.0||^7.0"
     },
     "require-dev": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "@headlessui/react": "^2.2.0",
-        "@inertiajs/react": "^2.3.7",
+        "@inertiajs/react": "^2.3.7 || ^3.0",
         "@radix-ui/react-avatar": "^1.1.3",
         "@radix-ui/react-checkbox": "^1.1.4",
         "@radix-ui/react-collapsible": "^1.1.3",

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -28,7 +28,7 @@
             }
         </style>
 
-        <title inertia>{{ config('app.name', 'Laravel') }}</title>
+        <title data-inertia>{{ config('app.name', 'Laravel') }}</title>
 
         @if (file_exists(public_path('hot-translations')))
             @php($hotUrl = trim(file_get_contents(public_path('hot-translations'))))

--- a/src/Concerns/HasDataTable.php
+++ b/src/Concerns/HasDataTable.php
@@ -139,8 +139,8 @@ trait HasDataTable
         }
 
         $query = QueryBuilder::for($this->tableBaseQuery())
-            ->allowedFilters($allowedFilters)
-            ->allowedSorts($this->buildAllowedSorts())
+            ->allowedFilters(...$allowedFilters)
+            ->allowedSorts(...$this->buildAllowedSorts())
             ->defaultSort($this->resolveDefaultSort());
 
         if ($relations = $this->tableRelations()) {
@@ -332,7 +332,7 @@ trait HasDataTable
             });
 
             if ($descending) {
-                $sort->defaultDirection(SortDirection::DESCENDING);
+                $sort->defaultDirection(defined(SortDirection::class.'::DESCENDING') ? SortDirection::DESCENDING : SortDirection::Descending);
             }
 
             return $sort;

--- a/src/Http/Controllers/GroupController.php
+++ b/src/Http/Controllers/GroupController.php
@@ -19,7 +19,7 @@ class GroupController extends Controller
     {
         $groups = QueryBuilder::for(Group::class)
             ->withCount('translationKeys')
-            ->allowedFilters([
+            ->allowedFilters(
                 AllowedFilter::callback('search', function ($query, $value): void {
                     $escaped = str_replace(['%', '_'], ['\%', '\_'], $value);
                     $query->where(function ($q) use ($escaped): void {
@@ -27,7 +27,7 @@ class GroupController extends Controller
                             ->orWhere('namespace', 'like', "%{$escaped}%");
                     });
                 }),
-            ])
+            )
             ->orderBy('name')
             ->get();
 


### PR DESCRIPTION
## Summary
- Add `^13.0` to `illuminate/contracts` and `illuminate/support` constraints
- Add `^11.0` to `orchestra/testbench` and `orchestra/workbench` constraints
- Add PHP 8.5 and Laravel 13 to CI matrix

## Blocked by
- `inertiajs/inertia-laravel` needs to add `^13.0` to their `laravel/framework` constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)