### PR TITLE
Fix: TranslationKey parameter validation fails due to case sensitivity

### DIFF
--- a/src/Models/TranslationKey.php
+++ b/src/Models/TranslationKey.php
@@ -62,6 +62,15 @@ class TranslationKey extends Model
         return $this->parameters ?? [];
     }
 
+    public function getNormalizedParameterNames(): array
+    {
+        $normalizedParameterNames = [];
+        foreach ($this->parameterNames() as $parameterName) {
+            $normalizedParameterNames[] = strtolower($parameterName);
+        }
+        return $normalizedParameterNames;
+    }
+
     public function scopeInGroup(Builder $query, int $groupId): Builder
     {
         return $query->where('group_id', $groupId);

--- a/src/Models/TranslationKey.php
+++ b/src/Models/TranslationKey.php
@@ -62,15 +62,6 @@ class TranslationKey extends Model
         return $this->parameters ?? [];
     }
 
-    public function getNormalizedParameterNames(): array
-    {
-        $normalizedParameterNames = [];
-        foreach ($this->parameterNames() as $parameterName) {
-            $normalizedParameterNames[] = strtolower($parameterName);
-        }
-        return $normalizedParameterNames;
-    }
-
     public function scopeInGroup(Builder $query, int $groupId): Builder
     {
         return $query->where('group_id', $groupId);

--- a/src/Rules/TranslationParametersRule.php
+++ b/src/Rules/TranslationParametersRule.php
@@ -26,7 +26,7 @@ class TranslationParametersRule implements ValidationRule
     public static function findMissing(TranslationKey $translationKey, string $value): array
     {
         return array_values(array_filter(
-            $translationKey->parameterNames(),
+            $translationKey->getNormalizedParameterNames(),
             fn (string $param) => ! str_contains(strtolower($value), $param),
         ));
     }

--- a/src/Rules/TranslationParametersRule.php
+++ b/src/Rules/TranslationParametersRule.php
@@ -26,8 +26,8 @@ class TranslationParametersRule implements ValidationRule
     public static function findMissing(TranslationKey $translationKey, string $value): array
     {
         return array_values(array_filter(
-            $translationKey->getNormalizedParameterNames(),
-            fn (string $param) => ! str_contains(strtolower($value), $param),
+            $translationKey->parameterNames(),
+            fn (string $param) => ! str_contains(strtolower($value), strtolower($param)),
         ));
     }
 }

--- a/src/Rules/TranslationParametersRule.php
+++ b/src/Rules/TranslationParametersRule.php
@@ -27,7 +27,7 @@ class TranslationParametersRule implements ValidationRule
     {
         return array_values(array_filter(
             $translationKey->parameterNames(),
-            fn (string $param) => ! str_contains($value, $param),
+            fn (string $param) => ! str_contains(strtolower($value), $param),
         ));
     }
 }

--- a/tests/Unit/Rules/TranslationParametersRuleTest.php
+++ b/tests/Unit/Rules/TranslationParametersRuleTest.php
@@ -126,6 +126,19 @@ it('passes when param is at end of string', function () {
     expect($validator->passes())->toBeTrue();
 });
 
+it('passes when param casing differs', function () {
+    $key = TranslationKey::factory()->create(['parameters' => [':attribute']]);
+
+    $rule = new TranslationParametersRule($key);
+
+    $validator = $this->app['validator']->make(
+        ['value' => ':Attribute is required'],
+        ['value' => [$rule]],
+    );
+
+    expect($validator->passes())->toBeTrue();
+});
+
 it('findMissing returns missing params', function () {
     $key = TranslationKey::factory()->create(['parameters' => [':attribute', ':max']]);
 
@@ -148,4 +161,20 @@ it('findMissing returns all params when none present', function () {
     $missing = TranslationParametersRule::findMissing($key, 'Invalid field');
 
     expect($missing)->toBe([':attribute', ':max']);
+});
+
+it('findMissing returns empty array when param is found in a different case', function () {
+    $key = TranslationKey::factory()->create(['parameters' => [':attribute']]);
+
+    $missing = TranslationParametersRule::findMissing($key, ':Attribute is required');
+
+    expect($missing)->toBe([]);
+});
+
+it('findMissing preserves case of missing params', function () {
+    $key = TranslationKey::factory()->create(['parameters' => [':Attribute']]);
+
+    $missing = TranslationParametersRule::findMissing($key, 'Hello World !');
+
+    expect($missing)->toBe([':Attribute']);
 });


### PR DESCRIPTION
Excuse the PR without an Issue beforehand but templates are _not_ working.
Opening a new bug report loops back to the template selection page.

On to the issue:

When introducing a new translation string for a `TranslationKey` with parameters, validation will fail if the parameter is in a different case between the two strings - this can happen when the parameter is upper case in some languages but lowercase in others (and Laravel supports this use case, ref: [docs](https://laravel.com/docs/13.x/localization#replacing-parameters-in-translation-strings))

```php

# in /app/lang/en/validation.php

return [
    //...
    'required' => 'the :attribute field is required',
    //...
];

# in /app/lang/it/validation.php

return [
    //...
    'required' => ':Attribute è un campo richiesto',
    //....
];

```

The above translation string for `'validation.required'` is currently unattainable because validation will check for the presence of `':attribute'` exactly in the string.

Fix:

just normalize both strings before checking.
To achieve this, I wrapped the `$value` being checked in `strtolower()` and I added a `getNormalizedParameterNames()` method to the `TranslationKey` class rather than changing `parameterNames()` because I imagine it would have messed with other pieces of code, such as labels, where maintaining the original capitalization would make more sense.

Also, you may want to double-check issue templates.