### PR TITLE
fix(github): add bug report template and drop looping contact link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug report
+description: Report a reproducible bug
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to file a bug report. Please fill out the fields below so we can reproduce it quickly.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including what you expected to happen instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: input
+    id: package-version
+    attributes:
+      label: Package version
+      description: Which version of outhebox/laravel-translations are you using?
+      placeholder: e.g. v2.0.1
+    validations:
+      required: true
+
+  - type: input
+    id: laravel-version
+    attributes:
+      label: Laravel version
+      placeholder: e.g. 12.x
+    validations:
+      required: true
+
+  - type: input
+    id: php-version
+    attributes:
+      label: PHP version
+      placeholder: e.g. 8.4
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, or anything else that might help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,6 +9,3 @@ contact_links:
   - name: Report a security issue
     url: https://github.com/MohmmedAshraf/laravel-translations/security/policy
     about: Learn how to notify us for sensitive bugs
-  - name: Report a bug
-    url: https://github.com/MohmmedAshraf/laravel-translations/issues/new
-    about: Report a reproducible bug


### PR DESCRIPTION
The `Report a bug` entry in `ISSUE_TEMPLATE/config.yml` was a contact link pointing back at `/issues/new`. With `blank_issues_enabled: false` and no actual templates, that URL just renders the chooser again, so reporting a bug looped back to the template selection page (flagged in #182).

- Add a real `bug_report.yml` issue form (description, repro, package/Laravel/PHP versions, context)
- Remove the self-referencing `Report a bug` contact link

🤖 Generated with [Claude Code](https://claude.com/claude-code)