### PR TITLE
fix: prevent translators from setting approval status

### DIFF
--- a/src/Http/Requests/UpdatePhraseRequest.php
+++ b/src/Http/Requests/UpdatePhraseRequest.php
@@ -23,7 +23,11 @@ class UpdatePhraseRequest extends FormRequest
 
         return [
             'value' => ['nullable', 'string', new TranslationParametersRule($translationKey), new TranslationPluralRule($translationKey)],
-            'status' => ['sometimes', Rule::enum(TranslationStatus::class)],
+            'status' => [
+                'sometimes',
+                Rule::prohibitedIf(fn (): bool => ! (app('translations.auth')->role()?->canApproveTranslations() ?? false)),
+                Rule::enum(TranslationStatus::class),
+            ],
             'reviewer_feedback' => ['nullable', 'string', 'max:1000'],
         ];
     }

--- a/tests/Feature/Http/PhraseControllerExtendedTest.php
+++ b/tests/Feature/Http/PhraseControllerExtendedTest.php
@@ -72,6 +72,27 @@ it('resolves status as needs_review for translator role', function () {
     expect($translation->status->value)->toBe('needs_review');
 });
 
+it('forbids translators from setting translation status directly', function () {
+    config(['translations.approval_workflow' => true]);
+
+    $translator = Contributor::factory()->translator()->create();
+    $translator->languages()->attach($this->language);
+
+    $key = TranslationKey::factory()->create();
+
+    $this->actingAs($translator, 'translations')
+        ->put(route('ltu.phrases.update', [$this->language, $key]), [
+            'value' => 'Test translation',
+            'status' => 'approved',
+        ])
+        ->assertSessionHasErrors('status');
+
+    expect(Translation::query()
+        ->where('translation_key_id', $key->id)
+        ->where('language_id', $this->language->id)
+        ->exists())->toBeFalse();
+});
+
 it('allows explicit status to override auto-resolution', function () {
     config(['translations.approval_workflow' => true]);
 


### PR DESCRIPTION
## Summary

- reject client-supplied translation statuses from roles that cannot approve translations
- preserve explicit status overrides for owners and admins
- add regression coverage for translator attempts to submit `approved`

## Why

`UpdatePhraseRequest` accepted every valid `TranslationStatus` from translators. `PhraseController` only resolved the workflow status when the request omitted it, so a crafted request could submit `status=approved` and bypass the approval workflow.

The request now prohibits `status` for roles without `canApproveTranslations()`. Normal translator saves are unchanged and continue to resolve to `needs_review` when approval workflow is enabled.

## Checks

- `PhraseControllerExtendedTest.php`: 9 passed, 28 assertions
- Laravel Pint: passed
- PHP syntax checks: passed
- `git diff --check`: passed
